### PR TITLE
Add CI workflow for CV gem tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install JS lint deps
+        run: npm ci
+
+      - name: Run prettier lint
+        run: npm run lint:prettier
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3.5"
+
+      - name: Build and install gem
+        run: |
+          GEMSPEC=$(ls *.gemspec | head -n1)
+          gem build "$GEMSPEC"
+          GEM_NAME=$(ruby -e "spec = Gem::Specification.load('$GEMSPEC'); puts spec.name")
+          GEM_VERSION=$(ruby -e "spec = Gem::Specification.load('$GEMSPEC'); puts spec.version")
+          gem install --no-document "./${GEM_NAME}-${GEM_VERSION}.gem"
+
+      - name: Run tests
+        run: ruby -Ilib:test -e 'Dir["test/**/*_test.rb"].sort.each { |f| require File.expand_path(f) }'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+node_modules/
+vendor/
+*.gem
+Gemfile.lock
+package-lock.json
+**/*.map
+**/*.min.css
+**/*.min.js
+assets/**
+lib/assets/**
+_scripts/**
+**/*.liquid.js
+**/*.js.liquid
+_sass/font-awesome/**

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+plugins: ["@shopify/prettier-plugin-liquid"]
+printWidth: 150
+trailingComma: "es5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "al-folio-cv",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@shopify/prettier-plugin-liquid": "^1.10.0",
+        "prettier": "^3.8.0"
+      }
+    },
+    "node_modules/@shopify/liquid-html-parser": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@shopify/liquid-html-parser/-/liquid-html-parser-2.9.0.tgz",
+      "integrity": "sha512-bkI4tLbU47YUxpgbMa9fgeJjFEMvRNEFL644Yk0ZKo5H1IRzU4pPyCQ6PkGvb0JJnt7OZ+RDGvb6ZLCnAR2Z/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "line-column": "^1.0.2",
+        "ohm-js": "^17.0.0"
+      }
+    },
+    "node_modules/@shopify/prettier-plugin-liquid": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@shopify/prettier-plugin-liquid/-/prettier-plugin-liquid-1.10.0.tgz",
+      "integrity": "sha512-csHYjwuT34o8ja6EY0dUBYQS5UVwsKwRYxGiuG816Ov0B8lVd8FUjOwWUk2SnrNx3cGgL0no7z+Byapp7sC1Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shopify/liquid-html-parser": "^2.9.0",
+        "html-styles": "^1.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^2.0.0 || ^3.0.0"
+      }
+    },
+    "node_modules/html-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/html-styles/-/html-styles-1.0.0.tgz",
+      "integrity": "sha512-cDl5dcj73oI4Hy0DSUNh54CAwslNLJRCCoO+RNkVo+sBrjA/0+7E/xzvj3zH/GxbbBLGJhE0hBe1eg+0FINC6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/line-column": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+      "integrity": "sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^1.0.0",
+        "isobject": "^2.0.0"
+      }
+    },
+    "node_modules/ohm-js": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-17.5.0.tgz",
+      "integrity": "sha512-l4Sa7026+6jsvYbt0PXKmL+f+ML32fD++IznLgxDhx2t9Cx6NC7zwRqblCujPHGGmkQerHoeBzRutdxaw/S72g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "lint:prettier": "prettier . --check"
+  },
+  "devDependencies": {
+    "@shopify/prettier-plugin-liquid": "^1.10.0",
+    "prettier": "^3.8.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Prettier linting baseline to CV gem
- add Node lint steps to CI workflow before Ruby tests

## Validation
- `npm run lint:prettier`
